### PR TITLE
CMake fixes: VERSION_GREATER, explicit Parser dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.3)
 
-if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL 3.12.0)
+if("${CMAKE_VERSION}" VERSION_GREATER 3.11.999)
   cmake_policy(SET CMP0074 NEW)
 endif()
 

--- a/QueryRunner/CMakeLists.txt
+++ b/QueryRunner/CMakeLists.txt
@@ -8,4 +8,5 @@ if("${MAPD_EDITION_LOWER}" STREQUAL "ee")
 endif()
 
 add_library(QueryRunner ${query_runner_source_files})
+add_dependencies(QueryRunner Parser)
 target_link_libraries(QueryRunner ${MAPD_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
Fixes for two misc CMake issues that have popped up recently:

- use VERSION_GREATER instead of VERSION_GREATER_EQUAL (#262)
- cmake: explicitly set Parser as dependency of QueryRunner (Quansight/mapd#20)