### PR TITLE
jdbc: generate recognized syntax when using SetBoolean

### DIFF
--- a/java/mapdjdbc/src/main/java/com/mapd/jdbc/MapDPreparedStatement.java
+++ b/java/mapdjdbc/src/main/java/com/mapd/jdbc/MapDPreparedStatement.java
@@ -166,8 +166,8 @@ class MapDPreparedStatement implements PreparedStatement {
   @Override
   public void setBoolean(int parameterIndex, boolean x) throws SQLException {
     MAPDLOGGER.debug("Entered");
-    parmRep[parameterIndex - 1] = x ? "t" : "f";
-    parmIsString[parameterIndex - 1] = true;
+    parmRep[parameterIndex - 1] = x ? "true" : "false";
+    parmIsString[parameterIndex - 1] = false;
     parmIsNull[parameterIndex - 1] = false;
     repCount++;
   }


### PR DESCRIPTION
Previously the generated sql was of the form:

    WHERE column = "f"

which is not recognized by Calcite. Now it generates:

    WHERE column = false

Resolves #274