### PR TITLE
[ENH] Update to gcc6 and fix SAML deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ MapD has the following dependencies:
 | ------- | ----------- | -------- |
 | [CMake](https://cmake.org/) | 3.3 | yes |
 | [LLVM](http://llvm.org/) | 3.8-4.0, 6.0 | yes |
-| [GCC](http://gcc.gnu.org/) | 5.1 | no, if building with clang |
+| [GCC](http://gcc.gnu.org/) | 6.0 | no, if building with clang |
 | [Go](https://golang.org/) | 1.6 | yes |
 | [Boost](http://www.boost.org/) | 1.65.0 | yes |
 | [OpenJDK](http://openjdk.java.net/) | 1.7 | yes |

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -60,12 +60,12 @@ sudo apt install -y \
     flex-old \
     libxmlsec1-dev
 
-# Install gcc7
+# Install gcc6
 add-apt-repository ppa:ubuntu-toolchain-r/test -y
 apt update && apt upgrade -y
-apt install g++-7 -y
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
-                    --slave /usr/bin/g++ g++ /usr/bin/g++-7
+apt install g++-6 -y
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 \
+                    --slave /usr/bin/g++ g++ /usr/bin/g++-6
 update-alternatives --config gcc
 
 # Needed to find xmltooling and xml_security_c

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -181,7 +181,7 @@ download_make_install ${HTTP_DEPS}/xml-security-c-2.0.0.tar.gz "" "--without-xal
 #xmltooling and opensaml needs --with-boost
 VERS=3.0.2-nolog4shib
 wget --continue ${HTTP_DEPS}/xmltooling-$VERS.tar.gz
-tar xvf xmltooling-$VERS
+tar xvf xmltooling-$VERS.tar.gz
 pushd xmltooling-$VERS
 ./configure --prefix=$PREFIX --with-boost=$PREFIX
 make -j $(nproc)

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -24,8 +24,6 @@ sudo apt install -y \
     llvm \
     llvm-dev \
     clang-format \
-    gcc-5 \
-    g++-5 \
     libgoogle-glog-dev \
     golang \
     libssl-dev \
@@ -60,8 +58,15 @@ sudo apt install -y \
     automake \
     bison \
     flex-old \
-    libxerces-c-dev \
     libxmlsec1-dev
+
+# Install gcc7
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
+apt update && apt upgrade -y
+apt install g++-7 -y
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+                    --slave /usr/bin/g++ g++ /usr/bin/g++-7
+update-alternatives --config gcc
 
 # Needed to find xmltooling and xml_security_c
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib64/pkgconfig:$PKG_CONFIG_PATH
@@ -160,9 +165,37 @@ make install
 popd
 
 # OpenSAML
+
+#xml-security requires xerces >= 3.2
+VERS=3.2.2
+wget https://www-us.apache.org/dist//xerces/c/3/sources/xerces-c-$VERS.tar.gz
+tar xzvf xerces-c-$VERS.tar.gz
+pushd xerces-c-$VERS
+./configure --prefix=$PREFIX
+make -j $(nproc)
+make install
+popd
+
 download_make_install ${HTTP_DEPS}/xml-security-c-2.0.0.tar.gz "" "--without-xalan"
-download_make_install ${HTTP_DEPS}/xmltooling-3.0.2-nolog4shib.tar.gz
-download_make_install ${HTTP_DEPS}/opensaml-3.0.0-nolog4shib.tar.gz
+
+#xmltooling and opensaml needs --with-boost
+VERS=3.0.2-nolog4shib
+wget --continue ${HTTP_DEPS}/xmltooling-$VERS.tar.gz
+tar xvf xmltooling-$VERS
+pushd xmltooling-$VERS
+./configure --prefix=$PREFIX --with-boost=$PREFIX
+make -j $(nproc)
+make install
+popd
+
+VERS=3.0.0-nolog4shib
+wget --continue ${HTTP_DEPS}/opensaml-$VERS.tar.gz
+tar xvf opensaml-$VERS.tar.gz
+pushd opensaml-$VERS
+./configure --prefix=$PREFIX --with-boost=$PREFIX
+make -j $(nproc)
+make install
+popd
 
 cat > $PREFIX/mapd-deps.sh <<EOF
 PREFIX=$PREFIX


### PR DESCRIPTION
Based on #300 and #299, it appears that the dependencies should be updated. PR switches to gcc7 from 5, builds xerces 3.2.2 and configures two other libraries with `--with-boost`