### PR TITLE
Fixing assertion failure when query falls back to cpu when a subquery ran in gpu mode

### DIFF
--- a/QueryEngine/RelAlgAbstractInterpreter.h
+++ b/QueryEngine/RelAlgAbstractInterpreter.h
@@ -480,6 +480,7 @@ class RelAlgNode {
   virtual ~RelAlgNode() {}
 
   void setContextData(const void* context_data) const {
+    CHECK(!context_data_);
     context_data_ = context_data;
   }
 

--- a/QueryEngine/RelAlgAbstractInterpreter.h
+++ b/QueryEngine/RelAlgAbstractInterpreter.h
@@ -480,7 +480,6 @@ class RelAlgNode {
   virtual ~RelAlgNode() {}
 
   void setContextData(const void* context_data) const {
-    CHECK(!context_data_);
     context_data_ = context_data;
   }
 

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -370,7 +370,7 @@ ExecutionResult RelAlgExecutor::executeRelAlgSeq(std::vector<RaExecutionDesc>& e
   // subqueries are available throughout the execution of the sequence.
   for (auto subquery : subqueries_) {
     auto temp_table = subquery->getExecutionResult();
-    if (temp_table.get()) {
+    if (temp_table.get() && temporary_tables_.find(-(subquery->getRelAlg()->getId())) == temporary_tables_.end()) {
       addTemporaryTable(-(subquery->getRelAlg()->getId()), temp_table->getDataPtr());
     }
   }


### PR DESCRIPTION
This fixes an issue where assert failures are triggered on certain queries. If a sub query runs on gpu but the outer query fails to run on gpu due to space limitations, the whole query is retried on gpu. This then causes a few checks to fail.