### PR TITLE
Make JDBC driver respect column order for batch upload (issue #124)

### DIFF
--- a/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
+++ b/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
@@ -355,9 +355,9 @@ class OmniSciPreparedStatement implements PreparedStatement {
         Matcher matcher = REGEX_LOF_PATTERN.matcher(currentSQL);
         if (matcher.find()) {
           String listOfFields[] = matcher.group(1).trim().split("\\s*,+\\s*,*\\s*");
-          if (listOfFieds.length != parmCount) throw new SQLException("Exception: too many or too few values");
-          else if (Arrays.stream(listOfFieds).distinct().toArray().length != listOfFieds.length) throw new SQLException("Exception: duplicated column name");
-          fieldsOrder = new int[listOfFieds.length];
+          if (listOfFields.length != parmCount) throw new SQLException("Exception: too many or too few values");
+          else if (Arrays.stream(listOfFields).distinct().toArray().length != listOfFields.length) throw new SQLException("Exception: duplicated column name");
+          fieldsOrder = new int[listOfFields.length];
           List<String> listOfColumns = new ArrayList<String>();
           try {
             TTableDetails tableDetails = client.get_table_details(session, insertTableName);
@@ -369,8 +369,8 @@ class OmniSciPreparedStatement implements PreparedStatement {
             throw new SQLException(ex.toString());
           }
           for (int i=0; i<fieldsOrder.length; i++) {
-            fieldsOrder[i]=listOfColumns.indexOf(listOfFieds[i].toLowerCase());
-            if (fieldsOrder[i] == -1) throw new SQLException("Exception: column "+listOfFieds[i].toLowerCase()+" does not exist");
+            fieldsOrder[i]=listOfColumns.indexOf(listOfFields[i].toLowerCase());
+            if (fieldsOrder[i] == -1) throw new SQLException("Exception: column "+listOfFields[i].toLowerCase()+" does not exist");
           }
         }
 

--- a/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
+++ b/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
@@ -19,6 +19,8 @@ import com.mapd.thrift.server.MapD;
 import com.mapd.thrift.server.TStringRow;
 import com.mapd.thrift.server.TStringValue;
 import com.mapd.thrift.server.TMapDException;
+import com.mapd.thrift.server.TColumnType;
+import com.mapd.thrift.server.TTableDetails;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -40,6 +42,7 @@ import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -64,6 +67,7 @@ class OmniSciPreparedStatement implements PreparedStatement {
   private String brokenSQL[];
   private String parmRep[];
   private boolean parmIsNull[];
+  private int fieldsOrder[];
   private int repCount;
   private String session;
   private MapD.Client client;
@@ -73,6 +77,7 @@ class OmniSciPreparedStatement implements PreparedStatement {
   private boolean[] parmIsString = null;
   private List<TStringRow> rows = null;
   private static final Pattern REGEX_PATTERN = Pattern.compile("(?i)\\s+INTO\\s+(\\w+)");
+  private static final Pattern REGEX_LOF_PATTERN = Pattern.compile("(?i)\\s*insert\\s+into\\s+[\\w:\\.]+\\s*\\(([\\w:\\s:\\,:\\']+)\\)[\\w:\\s]+\\(");
 
   OmniSciPreparedStatement(String sql, String session, MapD.Client client) {
     MAPDLOGGER.debug("Entered");
@@ -346,17 +351,41 @@ class OmniSciPreparedStatement implements PreparedStatement {
     if (isInsert) {
       // take the values and use stream inserter to add them
       if (isNewBatch) {
+        // check for columns names 
+        Matcher matcher = REGEX_LOF_PATTERN.matcher(currentSQL);
+        if (matcher.find()) {
+          String listOfFieds[] = matcher.group(1).trim().split("\\s*,+\\s*,*\\s*");
+          if (listOfFieds.length != parmCount) throw new SQLException("Exception: too many or too few values");
+          else if (Arrays.stream(listOfFieds).distinct().toArray().length != listOfFieds.length) throw new SQLException("Exception: duplicated column name");
+          fieldsOrder = new int[listOfFieds.length];
+          List<String> listOfColumns = new ArrayList<String>();
+          try {
+            TTableDetails tableDetails = client.get_table_details(session, insertTableName);
+            for (TColumnType column : tableDetails.row_desc) {
+              listOfColumns.add(column.col_name.toLowerCase());
+            }
+          } 
+          catch (TException ex) {
+            throw new SQLException(ex.toString());
+          }
+          for (int i=0; i<fieldsOrder.length; i++) {
+            fieldsOrder[i]=listOfColumns.indexOf(listOfFieds[i].toLowerCase());
+            if (fieldsOrder[i] == -1) throw new SQLException("Exception: column "+listOfFieds[i].toLowerCase()+" does not exist");
+          }
+        }
+
         rows = new ArrayList(5000);
         isNewBatch = false;
       }
       // add data to stream
-
+      int o;
       TStringRow tsr = new TStringRow();
       for (int i = 0; i < parmCount; i++) {
         // place string in rows array
         TStringValue tsv = new TStringValue();
-        tsv.str_val = this.parmRep[i];
-        if (parmIsNull[i]) {
+        if (fieldsOrder != null) o=fieldsOrder[i]; else o=i;
+        tsv.str_val = this.parmRep[o];
+        if (parmIsNull[o]) {
           tsv.is_null = true;
         } else {
           tsv.is_null = false;

--- a/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
+++ b/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciPreparedStatement.java
@@ -354,7 +354,7 @@ class OmniSciPreparedStatement implements PreparedStatement {
         // check for columns names 
         Matcher matcher = REGEX_LOF_PATTERN.matcher(currentSQL);
         if (matcher.find()) {
-          String listOfFieds[] = matcher.group(1).trim().split("\\s*,+\\s*,*\\s*");
+          String listOfFields[] = matcher.group(1).trim().split("\\s*,+\\s*,*\\s*");
           if (listOfFieds.length != parmCount) throw new SQLException("Exception: too many or too few values");
           else if (Arrays.stream(listOfFieds).distinct().toArray().length != listOfFieds.length) throw new SQLException("Exception: duplicated column name");
           fieldsOrder = new int[listOfFieds.length];


### PR DESCRIPTION
When you try to load data in batch the column order specified on the insert statement is respected.

I placed the various checks and logic on the addBatch method to be able to throw SQLExceptions.

As Micheal said it would be better to use the load_table_binary call as it would be probably faster, but I preferred to adopt a conservative path.





