### PR TITLE
Comment out needs : cxx11

### DIFF
--- a/ThirdParty/Arrow/apache-arrow.rb
+++ b/ThirdParty/Arrow/apache-arrow.rb
@@ -11,7 +11,7 @@ class ApacheArrow < Formula
   depends_on "python" => :optional
   depends_on "python@2" => :optional
 
-  needs :cxx11
+  # needs :cxx11
 
   def install
     ENV.cxx11


### PR DESCRIPTION
Per https://github.com/OSGeo/homebrew-osgeo4mac/issues/626 and others, 
Homebrew changed its compiler toolchain such that this line causes 
errors. Removing this line allows for installation to continue.

Fixes #321