### PR TITLE
JDBC: Correction of issues and enhancements on OmniSciDatabaseMetaData class

### DIFF
--- a/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciConnection.java
+++ b/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciConnection.java
@@ -229,6 +229,7 @@ public class OmniSciConnection implements java.sql.Connection {
               (String) this.cP.get(Connection_enums.user_passwd),
               (String) this.cP.get(Connection_enums.db_name));
 
+      catalog = (String) this.cP.get(Connection_enums.db_name);
       logger.debug("Connected session is " + session);
 
     } catch (TTransportException ex) {

--- a/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciData.java
+++ b/java/omniscijdbc/src/main/java/com/omnisci/jdbc/OmniSciData.java
@@ -48,6 +48,7 @@ class OmniSciData {
   }
 
   void setNull(boolean b) {
+   if (colType == TDatumType.STR) tcolumn.data.addToStr_col(null); else tcolumn.data.addToInt_col(0);
     tcolumn.addToNulls(b);
   }
 


### PR DESCRIPTION
This patch correct the issues #163 #164 #310 #311

Enhancements
The new implementation of the getPrimaryKey method makes the driver compatible with Tableau 2019.1

Now the GetTables method returns a list of table and views of the current database if the schemaPattern is null or it matches the current database name