### PR TITLE
Fixing declaration of char[] buffers for csv import

### DIFF
--- a/Import/Importer.cpp
+++ b/Import/Importer.cpp
@@ -1798,7 +1798,7 @@ void Importer::set_geo_physical_import_buffer_columnar(
 static ImportStatus import_thread_delimited(
     int thread_id,
     Importer* importer,
-    std::shared_ptr<const char> sbuffer,
+    std::shared_ptr<const char[]> sbuffer,
     size_t begin_pos,
     size_t end_pos,
     size_t total_size,
@@ -3397,7 +3397,7 @@ ImportStatus Importer::importDelimited(const std::string& file_path,
     }
   }
 
-  std::shared_ptr<char> sbuffer(new char[alloc_size]);
+  std::shared_ptr<char[]> sbuffer(new char[alloc_size]);
   size_t current_pos = 0;
   size_t end_pos;
   bool eof_reached = false;
@@ -3442,7 +3442,7 @@ ImportStatus Importer::importDelimited(const std::string& file_path,
       }
       // unput residual
       int nresidual = size - end_pos;
-      std::unique_ptr<char> unbuf(nresidual > 0 ? new char[nresidual] : nullptr);
+      std::unique_ptr<char[]> unbuf(nresidual > 0 ? new char[nresidual] : nullptr);
       if (unbuf) {
         memcpy(unbuf.get(), sbuffer.get() + end_pos, nresidual);
       }


### PR DESCRIPTION
This came up when recompiling with jemalloc. The database hung while importing from csv. I then found the issue with the address sanitizer.